### PR TITLE
Fix regex.

### DIFF
--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -18,8 +18,8 @@ if !exists('g:jsdoc_additional_descriptions')
 endif
 
 function! jsdoc#insert()
-  let l:jsDocregex = '\s*\([a-zA-Z]*\)\s*[:=]\s*function\s*(\s*\(.*\)\s*).*'
-  let l:jsDocregex2 = '\s*function \([a-zA-Z]*\)\s*(\s*\(.*\)\s*).*'
+  let l:jsDocregex = '^.\{-}\s*\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*[:=]\s*function\s*(\s*\([^)]*\)\s*).*$'
+  let l:jsDocregex2 = '^.\{-}\s*function\s\+\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*(\s*\([^)]*\)\s*).*$'
 
   let l:line = getline('.')
   let l:indent = indent('.')


### PR DESCRIPTION
以下の2つのパターンでコメントが挿入されない不具合を修正しました。 
- 関数名に数字、_、$が含まれている 
- 関数式の形式 
### 例

``` javascript
// 数字
function foo1() {
}

// _
function foo_bar() {
}

// $
function $foo() {
}

// 関数式の形式
var foo = function() {
};
```
