### PR TITLE
Fixes: Generated comment block doesn't follow whitespace settings (tabs vs. spaces) #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Prompt for and add a description for the `@return` tag.
 **g:jsdoc_default_mapping** *default: 1*
 Set value to 0 to turn off default mapping of <C-l> :JsDoc<cr>
 
-**g:jsdoc_access_descriptions *default: 0*
+**g:jsdoc_access_descriptions** *default: 0*
 Set value to 1 to turn on access tags like `@access <private|public>`
 Set value to 2 to turn on access tags like `@<private|public>`
 
-**g:jsdoc_underscore_private *default: 0*
+**g:jsdoc_underscore_private** *default: 0*
 Set value to 1 to turn on detecting underscore starting functions as private convention

--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ Prompt for and add a description for the `@return` tag.
 
 **g:jsdoc_default_mapping** *default: 1*
 Set value to 0 to turn off default mapping of <C-l> :JsDoc<cr>
+
+**g:jsdoc_access_descriptions *default: 0*
+Set value to 1 to turn on access tags like `@access <private|public>`
+Set value to 2 to turn on access tags like `@<private|public>`
+
+**g:jsdoc_underscore_private *default: 0*
+Set value to 1 to turn on detecting underscore starting functions as private convention


### PR DESCRIPTION
This should fix "Generated comment block doesn't follow whitespace settings (tabs vs. spaces) #11"

Also added these flags (and you can see the example effects below):

```
/**
 * g:jsdoc_access_descriptions = 1
 * g:jsdoc_underscore_private = 1
 */

/**
 * my function
 *
 * @public
 * @param {number} x x coor
 * @param {number} y y coor
 * @return {undefined}
 */
function myFunction(x, y) {
}

/**
 * my function 2
 *
 * @private
 * @param {number} x x coor
 * @param {number} y y coor
 * @return {undefined}
 */
function _myFunction2(x, y) {
}

/**
 * g:jsdoc_access_descriptions = 2
 * g:jsdoc_underscore_private = 1
 */

/**
 * my function
 *
 * @access public
 * @param {number} x x coor
 * @param {number} y y coor
 * @return {undefined}
 */
function myFunction(x, y) {
}

/**
 * my function 2
 *
 * @access private
 * @param {number} x x coor
 * @param {number} y y coor
 * @return {undefined}
 */
function _myFunction2(x, y) {
}


/**
 * g:jsdoc_access_descriptions = 2
 * g:jsdoc_underscore_private = 0
 */

/**
 * my function
 *
 * @access public
 * @param {number} x x coor
 * @param {number} y y coor
 * @return {undefined}
 */
function myFunction(x, y) {
}

/**
 * my function 2
 *
 * @access public
 * @param {number} x x coor
 * @param {number} y y coor
 * @return {undefined}
 */
function _myFunction2(x, y) {
}

/**
 * g:jsdoc_access_descriptions = 0
 * g:jsdoc_underscore_private = 0
 */


/**
 * my function
 *
 * @param {number} x x coor
 * @param {number} y y coor
 * @return {undefined}
 */
function myFunction(x, y) {
}

/**
 * my function 2
 *
 * @param {number} x x coor
 * @param {number} y y coor
 * @return {undefined}
 */
function _myFunction2(x, y) {
}
```
