### PR TITLE
Omit `return` tag if the input for return type is blank.

### DIFF
--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -161,8 +161,6 @@ function! jsdoc#insert()
           let l:returnDescription = ' ' . l:returnDescription
         endif
         call add(l:lines, l:space . ' * @return {' . l:returnType . '}' . l:returnDescription)
-      else
-        call add(l:lines, l:space . ' * @return {undefined}')
       endif
     else
       call add(l:lines, l:space . ' * @return {undefined}')


### PR DESCRIPTION
This fixes #17. This is my first pull request: please let me know if I've messed anything up!