### PR TITLE
Enable user to use the plural form of `@return`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Prompt for and add a type for the aforementioned `@return` tag.
 **g:jsdoc_return_description** *default: 1*
 Prompt for and add a description for the `@return` tag.
 
+**g:jsdoc_return_plural** *default: 0*
+Use the `@returns` tag instead of `@return`.
+
 **g:jsdoc_default_mapping** *default: 1*
 Set value to 0 to turn off default mapping of <C-l> :JsDoc<cr>
 

--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -20,6 +20,10 @@ endif
 if !exists('g:jsdoc_return')
   let g:jsdoc_return = 1
 endif
+" Set @return tag plurality
+if !exists('g:jsdoc_return_plural')
+  let g:jsdoc_return_plural = 0
+endif
 " Prompt user for return description
 if !exists('g:jsdoc_return_description')
   let g:jsdoc_return_description = 1
@@ -154,8 +158,12 @@ function! jsdoc#insert()
     endfor
   endif
   if g:jsdoc_return == 1
+    let l:returnTag = '@return'
+    if g:jsdoc_return_plural == 1
+      let l:returnTag = l:returnTag . 's'
+    endif
     if g:jsdoc_allow_input_prompt == 1
-      let l:returnType = input('Return type (blank for no @return): ', '', 'custom,jsdoc#listDataTypes')
+      let l:returnType = input('Return type (blank for no ' . l:returnTag . '): ', '', 'custom,jsdoc#listDataTypes')
       let l:returnDescription = ''
       if l:returnType != ''
         if g:jsdoc_return_description == 1
@@ -164,10 +172,10 @@ function! jsdoc#insert()
         if l:returnDescription != ''
           let l:returnDescription = ' ' . l:returnDescription
         endif
-        call add(l:lines, l:space . ' * @return {' . l:returnType . '}' . l:returnDescription)
+        call add(l:lines, l:space . ' * ' . l:returnTag . ' {' . l:returnType . '}' . l:returnDescription)
       endif
     else
-      call add(l:lines, l:space . ' * @return {undefined}')
+      call add(l:lines, l:space . ' * ' . l:returnTag . ' {undefined}')
     endif
   endif
   call add(l:lines, l:space . ' */')

--- a/doc/jsdoc.txt
+++ b/doc/jsdoc.txt
@@ -109,6 +109,11 @@ g:jsdoc_return_description		*g:jsdoc_return_description*
 
 		Default value is '1'
 
+g:jsdoc_return_plural			*g:jsdoc_return_plural
+		Use the `@returns` tag instead of `@return`.
+
+		Default value is '0'
+
 g:jsdoc_default_mapping			*g:jsdoc_default_mapping*
 		Automatically map to <C-l>
 


### PR DESCRIPTION
My team prefers (and enforces) `@returns`, so here's a PR of my personal hack to enable a configurable variation of the `@return` tag output.

The `@return` tag remains the default unless the `g:jsdoc_return_plural` option is set to 1.

```vim
g:jsdoc_return_plural			*g:jsdoc_return_plural
		Use the `@returns` tag instead of `@return`.

		Default value is '0'
```