### PR TITLE
Spelling and formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,36 +18,17 @@ Data type tab completion supported for parameter and return types
   3. Insert JsDoc above the `function` keyword line.
 
 ## Configuration
-**g:jsdoc_allow_input_prompt** *default: 0*
-Allow prompt for interactive input.
 
-**g:jsdoc_input_description** *default: 1*
-Prompt for a function description
-
-**g:jsdoc_additional_descriptions** *default: 0*
-Prompt for a value for `@name`, add it to the JSDoc block comment along with the `@function` tag.
-
-**g:jsdoc_return** *default: 1*
-Add the `@return` tag.
-
-**g:jsdoc_return_type** *default: 1*
-Prompt for and add a type for the aforementioned `@return` tag.
-
-**g:jsdoc_return_description** *default: 1*
-Prompt for and add a description for the `@return` tag.
-
-**g:jsdoc_default_mapping** *default: 1*
-Set value to 0 to turn off default mapping of <C-l> :JsDoc<cr>
-
-**g:jsdoc_access_descriptions** *default: 0*
-Set value to 1 to turn on access tags like `@access <private|public>`
-Set value to 2 to turn on access tags like `@<private|public>`
-
-**g:jsdoc_underscore_private** *default: 0*
-Set value to 1 to turn on detecting underscore starting functions as private convention
-
-**g:jsdoc_allow_shorthand** *default: 0*
-Set value to 1 to allow ECMAScript6 shorthand syntax.
-
-**g:jsdoc_param_description_seperator** *default: ' '*
-Characters used to seperate @param name and description.
+Option                                  | Default | Description
+:-------------------------------------- | :------ | :----------
+**g:jsdoc_allow_input_prompt**          | 0       | Allow prompt for interactive input.
+**g:jsdoc_input_description**           | 1       | Prompt for a function description
+**g:jsdoc_additional_descriptions**     | 0       | Prompt for a value for `@name`, add it to the JSDoc block comment along with the `@function` tag.
+**g:jsdoc_return**                      | 1       | Add the `@return` tag.
+**g:jsdoc_return_type**                 | 1       | Prompt for and add a type for the aforementioned `@return` tag.
+**g:jsdoc_return_description**          | 1       | Prompt for and add a description for the `@return` tag.
+**g:jsdoc_default_mapping**             | 1       | Set value to 0 to turn off default mapping of `<C-l> :JsDoc<cr>`
+**g:jsdoc_access_descriptions**         | 0       | Set value to 1 to turn on access tags like `@access <private|public>`. Set value to 2 to turn on access tags like `@<private|public>`
+**g:jsdoc_underscore_private**          | 0       | Set value to 1 to turn on detecting underscore starting functions as private convention
+**g:jsdoc_allow_shorthand**             | 0       | Set value to 1 to allow ECMAScript6 shorthand syntax.
+**g:jsdoc_param_description_separator** | ' '     | Characters used to separate `@param` name and description.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 jsdoc.vim
 =========
 
-jsdoc.vim generates JSDoc block comments based on a function signature.
+jsdoc.vim generates [JSDoc](http://usejsdoc.org/) block comments based on a function signature.
 
 ![image](https://github.com/heavenshell/vim-jsdoc/wiki/images/vim-jsdoc-screencast-preview.gif)
 
 This plugin based on https://gist.github.com/3903772#file-jsdoc-vim written by [NAKAMURA, Hisashi](https://gist.github.com/sunvisor)
 
-Depending on your confuguration, jsdoc.vim will prompt for description, `@return` type and description. It will also prompt you for types and descriptions for each function `@param`.
+Depending on your configuration, jsdoc.vim will prompt for description, `@return` type and description. It will also prompt you for types and descriptions for each function `@param`.
 
 Data type tab completion supported for parameter and return types
 * currently: `boolean`, `null`, `undefined`, `number`, `string`, `symbol`, `object`
 
 ## Usage
+
   1. Move cursor on `function` keyword line.
-  2. Type `:JsDoc` or `<C-l>` which is default key mapping to insert JsDoc.
-  3. Insert JsDoc above the `function` keyword line.
+  2. Type `:JsDoc` or `<C-l>` which is default key mapping to insert JSDoc.
+  3. Insert JSDoc above the `function` keyword line.
 
 ## Configuration
 

--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -3,7 +3,7 @@
 " Modifyed: Shinya Ohyanagi <sohyanagi@gmail.com>
 " Version:  0.2.0
 " WebPage:  http://github.com/heavenshell/vim-jsdoc/
-" Description: Generate JsDoc to your JavaScript file.
+" Description: Generate JSDoc to your JavaScript file.
 " License: BSD, see LICENSE for more details.
 
 let s:save_cpo = &cpo

--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -50,9 +50,9 @@ endif
 if !exists('g:jsdoc_allow_shorthand')
   let g:jsdoc_allow_shorthand = 0
 endif
-" Use seperator between @param name and description.
-if !exists('g:jsdoc_param_description_seperator')
-    let g:jsdoc_param_description_seperator = " "
+" Use separator between @param name and description.
+if !exists('g:jsdoc_param_description_separator')
+    let g:jsdoc_param_description_separator = " "
 endif
 
 " Insert defined type and description if arg is matched to defined regex.
@@ -76,7 +76,7 @@ function! s:hookArgs(lines, space, arg, hook, argType, argDescription)
       let l:type = '{' . a:argType . '} '
       let l:description = ''
       if a:argDescription != ''
-        let l:description = g:jsdoc_param_description_seperator . a:argDescription
+        let l:description = g:jsdoc_param_description_separator . a:argDescription
       endif
       call add(a:lines, a:space . ' * @param ' . l:type . a:arg . l:description)
     else
@@ -92,10 +92,10 @@ function! s:hookArgs(lines, space, arg, hook, argType, argDescription)
       let l:description = ''
       if a:argDescription == ''
         if has_key(l:customArg, 'description')
-          let l:description = g:jsdoc_param_description_seperator . l:customArg['description']
+          let l:description = g:jsdoc_param_description_separator . l:customArg['description']
         endif
       else
-        let l:description = g:jsdoc_param_description_seperator . a:argDescription
+        let l:description = g:jsdoc_param_description_separator . a:argDescription
       endif
       call add(a:lines, a:space . ' * @param ' . l:type . a:arg . l:description)
     endif
@@ -188,9 +188,9 @@ function! jsdoc#insert()
         let l:argDescription = input('Argument "' . l:arg . '" description: ')
 
         if g:jsdoc_custom_args_hook == {}
-          " Prepend seperator to start of description only if it was provided
+          " Prepend separator to start of description only if it was provided
           if l:argDescription != ''
-            let l:argDescription = g:jsdoc_param_description_seperator . l:argDescription
+            let l:argDescription = g:jsdoc_param_description_separator . l:argDescription
           endif
           call add(l:lines, l:space . ' * @param {' . l:argType . '} ' . l:arg . l:argDescription)
         else

--- a/doc/jsdoc.txt
+++ b/doc/jsdoc.txt
@@ -1,4 +1,4 @@
-*jsdoc.txt*	Generate JsDoc to your JavaScript code.
+*jsdoc.txt*	Generate JSDoc to your JavaScript code.
 
 Version: 0.2.0
 Author: NAKAMURA, Hisashi <https://github.com/sunvisor>
@@ -17,7 +17,7 @@ Variables		|jsdoc-variables|
 ==============================================================================
 INTRODUCTION					*jsdoc-vim-introduction*
 
-|jsdoc| is a generater of JsDoc.
+|jsdoc| is a generator of JSDoc.
 
 - This plugin based on https://gist.github.com/3903772#file-jsdoc-vim
   written by NAKAMURA, Hisashi(https://gist.github.com/sunvisor)
@@ -74,7 +74,7 @@ VARIABLES					*jsdoc-vim-variables*
 
 g:jsdoc_additional_descriptions		*g:jsdoc_additional_descriptions*
 		If g:jsdoc_input_description is '1' @function and @name
-		append to JsDoc.
+		append to JSDoc.
 
 		Default value is '0'
 
@@ -86,9 +86,9 @@ g:jsdoc_input_description		*g:jsdoc_input_description*
 
 g:jsdoc_allow_input_prompt		*g:jsdoc_allow_input_prompt*
 		Allow prompt for a value for `@param`, `@return`
-		add it to the JsDoc block.
+		add it to the JSDoc block.
 		If prompt not allowed, only `@param`, `@return` add to the
-		JsDoc.
+		JSDoc.
 		This variables affects to g:jsdoc_return_type and
 		g:jsdoc_return_description.
 
@@ -158,9 +158,9 @@ g:jsdoc_custom_args_hook		*g:jsdoc_custom_args_hook*
 		\}
 
 		The key of g:jsdoc_custom_args_hook is regex to hook
-		If function's signeture include `callback` or `cb`
-		and g:jsdoc_custom_args_hook's key matched JsDoc.vim would
-		genrate like following.
+		If function's signature include `callback` or `cb`
+		and g:jsdoc_custom_args_hook's key matched jsdoc.vim would
+		generate like following.
 
 		/**
 		 * foo

--- a/doc/jsdoc.txt
+++ b/doc/jsdoc.txt
@@ -135,9 +135,9 @@ g:jsdoc_allow_shorthand			*g:jsdoc_allow_shorthand*
 
 		Default value is '0'
 
-g:jsdoc_param_description_seperator	*g:jsdoc_param_description_seperator*
+g:jsdoc_param_description_separator	*g:jsdoc_param_description_separator*
 
-		Characters used to seperate @param name and description
+		Characters used to separate @param name and description
 		for more readable descriptions.
 
 		Default value is ' '
@@ -183,7 +183,7 @@ CHANGELOG					*jsdoc-changelog*
 - Add g:jsdoc_custom_args_hook to override default type and description.
 
 2015-05-27
-- Add seperator between @param's name and description for better readability.
+- Add separator between @param's name and description for better readability.
   (thx @aars)
 
 2015-04-28

--- a/ftplugin/javascript/jsdoc.vim
+++ b/ftplugin/javascript/jsdoc.vim
@@ -3,7 +3,7 @@
 " Modifyed: Shinya Ohyanagi <sohyanagi@gmail.com>
 " Version:  0.2.0
 " WebPage:  http://github.com/heavenshell/vim-jsdoc/
-" Description: Generate JsDoc to your JavaScript file.
+" Description: Generate JSDoc to your JavaScript file.
 " License: BSD, see LICENSE for more details.
 
 let s:save_cpo = &cpo


### PR DESCRIPTION
Briefly tested.

the
```vim
g:jsdoc_param_description_seperator
```
to
```vim
g:jsdoc_param_description_separator
```

Above is a breaking change if any user is using the former. Maybe want to support both? Or maybe you want to keep the old version. Anyway I put the correct english spelling so it is your call :smile: 
