### PR TITLE
Adds support for tag synonyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Option                                  | Default | Description
 **g:jsdoc_custom_args_hook**            | {}      | Override default type and description. See help more detail.
 **g:jsdoc_type_hook**                   | {}      | Allow to insert default description depending on the type.
 **g:jsdoc_enable_es6**                  | 0       | Enable to use ECMAScript6's Shorthand function, Arrow function.
+**g:jsdoc_tags**                        | see :h  | Allow use of alternate tags (the ones that support synonyms) per JSDoc documentation. Can be changed on a per tag basis, for example: `let g:jsdoc_tags = {} | let g:jsdoc_tags['param'] = 'arg'`
 
 ## Keymap
 Since version `0.3`, `g:jsdoc_default_mapping` was removed.

--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -64,6 +64,32 @@ if !exists('g:jsdoc_type_hook')
   let g:jsdoc_type_hook = {}
 endif
 
+if !exists('g:jsdoc_tags')
+  let g:jsdoc_tags = {}
+endif
+
+" Allows for use of custom synonyms
+" e.g. @return instead of @returns
+" possible list:
+" @returns (synonyms: @return)
+" @function (synonyms: @func, @method)
+" @param (synonyms: @arg, @argument)
+" @description (synonyms: @desc)
+" @class (synonyms: @constructor)
+let s:jsdoc_tags = {
+  \  'returns': 'returns',
+  \  'function': 'function',
+  \  'param': 'param',
+  \  'class': 'class'
+\}
+
+" iterate over to allow user overriding of specific individual keys in vimrc
+for [key, val] in items(s:jsdoc_tags)
+  if !has_key(g:jsdoc_tags, key)
+    let g:jsdoc_tags[key] = val
+  endif
+endfor
+
 " Return data types for argument type auto completion :)
 function! jsdoc#listDataTypes(A, L, P)
   let l:types = ['boolean', 'null', 'undefined', 'number', 'string', 'symbol', 'object', 'function', 'array']
@@ -118,7 +144,7 @@ endfunction
 function! s:hookArgs(lines, space, arg, hook, argType, argDescription)
   " Hook function signature's args for insert as default value.
   if g:jsdoc_custom_args_hook == {}
-    call add(a:lines, a:space . ' * @param ' . a:arg)
+    call add(a:lines, a:space . ' * @' . g:jsdoc_tags['param'] . ' ' . a:arg)
   else
     let l:matchedArg = matchstr(a:hook, a:arg)
     if l:matchedArg == ''
@@ -127,7 +153,7 @@ function! s:hookArgs(lines, space, arg, hook, argType, argDescription)
       if a:argDescription != ''
         let l:description = g:jsdoc_param_description_separator . a:argDescription
       endif
-      call add(a:lines, a:space . ' * @param ' . l:type . a:arg . l:description)
+      call add(a:lines, a:space . ' * @' . g:jsdoc_tags['param'] . ' ' . l:type . a:arg . l:description)
     else
       let l:type = ''
       let l:customArg = g:jsdoc_custom_args_hook[l:matchedArg]
@@ -146,7 +172,7 @@ function! s:hookArgs(lines, space, arg, hook, argType, argDescription)
       else
         let l:description = g:jsdoc_param_description_separator . a:argDescription
       endif
-      call add(a:lines, a:space . ' * @param ' . l:type . a:arg . l:description)
+      call add(a:lines, a:space . ' * @' . g:jsdoc_tags['param'] . ' ' . l:type . a:arg . l:description)
     endif
   endif
   return a:lines
@@ -202,7 +228,7 @@ function! jsdoc#insert()
 
     if g:jsdoc_additional_descriptions == 1
       call add(l:lines, l:space . ' * @name ' . l:funcName)
-      call add(l:lines, l:space . ' * @function')
+      call add(l:lines, l:space . ' * @' . g:jsdoc_tags['function'])
     endif
 
     if g:jsdoc_access_descriptions > 0
@@ -242,7 +268,7 @@ function! jsdoc#insert()
           if l:argDescription != ''
             let l:argDescription = g:jsdoc_param_description_separator . l:argDescription
           endif
-          call add(l:lines, l:space . ' * @param {' . l:argType . '} ' . l:arg . l:argDescription)
+          call add(l:lines, l:space . ' * @' . g:jsdoc_tags['param'] . ' {' . l:argType . '} ' . l:arg . l:argDescription)
         else
           let l:lines = s:hookArgs(l:lines, l:space, l:arg, l:hook, l:argType, l:argDescription)
         endif
@@ -254,7 +280,7 @@ function! jsdoc#insert()
   endif
   if g:jsdoc_return == 1
     if g:jsdoc_allow_input_prompt == 1
-      let l:returnType = input('Return type (blank for no @return): ', '', 'custom,jsdoc#listDataTypes')
+      let l:returnType = input('Return type (blank for no @' . g:jsdoc_tags['returns'] . '): ', '', 'custom,jsdoc#listDataTypes')
       let l:returnDescription = ''
       if l:returnType != ''
         if g:jsdoc_return_description == 1
@@ -263,10 +289,10 @@ function! jsdoc#insert()
         if l:returnDescription != ''
           let l:returnDescription = ' ' . l:returnDescription
         endif
-        call add(l:lines, l:space . ' * @return {' . l:returnType . '}' . l:returnDescription)
+        call add(l:lines, l:space . ' * @' . g:jsdoc_tags['returns'] . ' {' . l:returnType . '}' . l:returnDescription)
       endif
     else
-      call add(l:lines, l:space . ' * @return {undefined}')
+      call add(l:lines, l:space . ' * @' . g:jsdoc_tags['returns'] . ' {undefined}')
     endif
   endif
   call add(l:lines, l:space . ' */')

--- a/doc/jsdoc.txt
+++ b/doc/jsdoc.txt
@@ -130,7 +130,7 @@ g:jsdoc_allow_shorthand			*g:jsdoc_allow_shorthand*
 		Default value is '0'
 		Deprecated since ver 0.5.0
 
-g:jsdoc_param_description_separator	*g:jsdoc_param_description_separator*
+g:jsdoc_param_description_separator		*g:jsdoc_param_description_separator*
 
 		Characters used to separate @param name and description
 		for more readable descriptions.
@@ -196,6 +196,20 @@ g:jsdoc_enable_es6					*g:jsdoc_enable_es6*
 		- Arrow function
 		Default value is '0'
 
+g:jsdoc_tags						*g:jsdoc_tags*
+		Allow use of alternate tags
+		(the ones that support synonyms) per JsDoc
+		documentation.
+
+		Default value is:
+			{
+			  \  'returns': 'returns',
+			  \  'function': 'function',
+			  \  'param': 'param',
+			  \  'class': 'class'
+			\}
+>
+		Can be changed on a per tag basis, for example: let g:jsdoc_tags = {} | let g:jsdoc_tags['param'] = 'arg'
 
 ==============================================================================
 CHANGELOG					*jsdoc-changelog*


### PR DESCRIPTION
* currently for: @returns, @param, @function, @class
* originally discussed on PR #23 (... plural form of '@return')
* makes '@returns' the default per JSDoc

Not sure if/how you want to version bump, also this would change the default from 'return' to 'returns' so I am not sure if you want to change the default back (I went with what looked to be the default on JSDoc website).

I tested a few method types with and without some `vimrc` settings:
```vim
" test synonyms
let g:jsdoc_tags = {}
let g:jsdoc_tags['param'] = 'arg'
let g:jsdoc_tags['returns'] = 'return'
```