### PR TITLE
vimlint and function generator regex support

### DIFF
--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -52,7 +52,7 @@ if !exists('g:jsdoc_allow_shorthand')
 endif
 " Use separator between @param name and description.
 if !exists('g:jsdoc_param_description_separator')
-    let g:jsdoc_param_description_separator = " "
+    let g:jsdoc_param_description_separator = ' '
 endif
 
 " Insert defined type and description if arg is matched to defined regex.
@@ -84,14 +84,14 @@ let s:jsdoc_tags = {
 \}
 
 " iterate over to allow user overriding of specific individual keys in vimrc
-for [key, val] in items(s:jsdoc_tags)
-  if !has_key(g:jsdoc_tags, key)
-    let g:jsdoc_tags[key] = val
+for [s:key, s:val] in items(s:jsdoc_tags)
+  if !has_key(g:jsdoc_tags, s:key)
+    let g:jsdoc_tags[s:key] = s:val
   endif
 endfor
 
 " Return data types for argument type auto completion :)
-function! jsdoc#listDataTypes(A, L, P)
+function! jsdoc#listDataTypes(A, L, P) abort
   let l:types = ['boolean', 'null', 'undefined', 'number', 'string', 'symbol', 'object', 'function', 'array']
   return join(l:types, "\n")
 endfunction
@@ -113,39 +113,41 @@ endif
 " If `const foo = (arg1, arg2) => true;` extracts `(arg`, `arg2)`.
 " We don't need `(` and `)`.
 " Currently `(` and `)` are deleted by substitute().
+" @see jsdoc#insert() for where these regexes are matched to the string
 let s:regexs = {
-  \  'method': '^.\{-}\s*\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*[:=]\s*function\s*\**(\s*\([^)]*\)\s*).*$',
-  \  'function': '^.\{-}\s*function\s\+\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*\**(\s*\([^)]*\)\s*).*$',
-  \  'shorthand': '^.\{-}\s*\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*(\s*\([^)]*\)\s*).*$',
-  \  'arrow': '^.\{-}\s*\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*[:=]\s*\(\([^)]*\)\s*)\|[a-zA-Z0-9_$]*\)\s=>.*$'
+  \  'function_declaration':  '^.\{-}\s*function\s*\*\?\s\+\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*\**(\s*\([^)]*\)\s*).*$',
+  \  'function_expression':   '^.\{-}\s*\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*[:=]\s*function\s*\**\s*(\s*\([^)]*\)\s*).*$',
+  \  'anonymous_function':    '^.\{-}\s*function\s*\**\s*(\s*\([^)]*\)\s*).*$',
+  \  'shorthand':             '^.\{-}\s*\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*(\s*\([^)]*\)\s*).*$',
+  \  'arrow':                 '^.\{-}\s*\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*[:=]\s*\(\([^)]*\)\s*)\|[a-zA-Z0-9_$]*\)\s=>.*$'
 \ }
 
-function! s:build_description(argType, arg)
-  let description = ''
-  let override = 0
+function! s:build_description(argType, arg) abort
+  let l:description = ''
+  let l:override = 0
   if has_key(g:jsdoc_type_hook, a:argType)
     if type(g:jsdoc_type_hook[a:argType]) == 1
-      let description = g:jsdoc_type_hook[a:argType]
+      let l:description = g:jsdoc_type_hook[a:argType]
     elseif type(g:jsdoc_type_hook[a:argType]) == 4
       if has_key(g:jsdoc_type_hook[a:argType], 'force_override')
-        let override = g:jsdoc_type_hook[a:argType]['force_override']
+        let l:override = g:jsdoc_type_hook[a:argType]['force_override']
       endif
       if has_key(g:jsdoc_type_hook[a:argType], 'description')
-        let description = g:jsdoc_type_hook[a:argType]['description']
+        let l:description = g:jsdoc_type_hook[a:argType]['description']
       endif
     endif
   endif
-  if override == 0
-    let inputDescription = input('Argument "' . a:arg . '" description: ')
-    if inputDescription != ''
-      let description = inputDescription
+  if l:override == 0
+    let l:inputDescription = input('Argument "' . a:arg . '" description: ')
+    if l:inputDescription !=# ''
+      let l:description = l:inputDescription
     endif
   endif
 
-  return description
+  return l:description
 endfunction
 
-function! s:hookArgs(lines, space, arg, hook, argType, argDescription)
+function! s:hookArgs(lines, space, arg, hook, argType, argDescription) abort
   " Hook function signature's args for insert as default value.
   if g:jsdoc_custom_args_hook == {}
     call add(a:lines, a:space . ' * @' . g:jsdoc_tags['param'] . ' ' . a:arg)
@@ -166,17 +168,17 @@ function! s:hookArgs(lines, space, arg, hook, argType, argDescription)
       let l:matchedArg = matchstr(a:hook, a:arg)
     endif
 
-    if l:matchedArg == ''
+    if l:matchedArg ==# ''
       let l:type = '{' . a:argType . '} '
       let l:description = ''
-      if a:argDescription != ''
+      if a:argDescription !=# ''
         let l:description = g:jsdoc_param_description_separator . a:argDescription
       endif
       call add(a:lines, a:space . ' * @' . g:jsdoc_tags['param'] . ' ' . l:type . a:arg . l:description)
     else
       let l:type = ''
       let l:customArg = g:jsdoc_custom_args_hook[l:matchedArg]
-      if a:argType == ''
+      if a:argType ==# ''
         if has_key(l:customArg, 'type')
           let l:type = l:customArg['type'] . ' '
         endif
@@ -184,7 +186,7 @@ function! s:hookArgs(lines, space, arg, hook, argType, argDescription)
         let l:type = '{' . a:argType . '} '
       endif
       let l:description = ''
-      if a:argDescription == ''
+      if a:argDescription ==# ''
         if has_key(l:customArg, 'description')
           let l:description = g:jsdoc_param_description_separator . l:customArg['description']
         endif
@@ -197,7 +199,7 @@ function! s:hookArgs(lines, space, arg, hook, argType, argDescription)
   return a:lines
 endfunction
 
-function! jsdoc#insert()
+function! jsdoc#insert() abort
   let l:line = getline('.')
   let l:indentCharSpace = ' '
   let l:indentCharTab = '	'
@@ -215,12 +217,15 @@ function! jsdoc#insert()
 
   let l:space = repeat(l:indentChar, l:indent)
 
-  if l:line =~ s:regexs['function']
+  if l:line =~ s:regexs['function_declaration']
     let l:flag = 1
-    let l:regex = s:regexs['function']
-  elseif l:line =~ s:regexs['method']
+    let l:regex = s:regexs['function_declaration']
+  elseif l:line =~ s:regexs['function_expression']
     let l:flag = 1
-    let l:regex = s:regexs['method']
+    let l:regex = s:regexs['function_expression']
+  elseif l:line =~ s:regexs['anonymous_function']
+    let l:flag = 2
+    let l:regex = s:regexs['anonymous_function']
   elseif (g:jsdoc_allow_shorthand == 1 || g:jsdoc_enable_es6 == 1) && l:line =~ s:regexs['shorthand']
     let l:flag = 1
     let l:regex = s:regexs['shorthand']
@@ -241,9 +246,17 @@ function! jsdoc#insert()
   call add(l:lines, l:space . ' *')
   let l:funcName = ''
   if l:flag
-    let l:funcName = substitute(l:line, l:regex, '\1', "g")
-    let l:arg = substitute(l:line, l:regex, '\2', "g")
-    let l:args = split(l:arg, '\s*,\s*')
+
+    if l:flag == 1
+      let l:funcName = substitute(l:line, l:regex, '\1', 'g')
+      let l:arg = substitute(l:line, l:regex, '\2', 'g')
+    elseif l:flag == 2
+      let l:arg = substitute(l:line, l:regex, '\1', 'g')
+    endif
+
+    if !empty(l:arg)
+      let l:args = split(l:arg, '\s*,\s*')
+    endif
 
     if g:jsdoc_additional_descriptions == 1
       call add(l:lines, l:space . ' * @name ' . l:funcName)
@@ -256,7 +269,7 @@ function! jsdoc#insert()
       if g:jsdoc_underscore_private == 1
         let l:funcNameFirstChar = l:funcName[0]
 
-        if l:funcNameFirstChar == '_'
+        if l:funcNameFirstChar ==# '_'
           let l:access = 'private'
         endif
       endif
@@ -273,18 +286,18 @@ function! jsdoc#insert()
 
     endif
 
-    let hook = keys(g:jsdoc_custom_args_hook)
+    let l:hook = keys(g:jsdoc_custom_args_hook)
     for l:arg in l:args
       if g:jsdoc_enable_es6 == 1
         " Remove `(` or `)` from args.
-        let l:arg = substitute(l:arg, '\((\|)\)', "", "")
+        let l:arg = substitute(l:arg, '\((\|)\)', '', '')
       endif
       if g:jsdoc_allow_input_prompt == 1
         let l:argType = input('Argument "' . l:arg . '" type: ', '', 'custom,jsdoc#listDataTypes')
         let l:argDescription = s:build_description(l:argType, l:arg)
         if g:jsdoc_custom_args_hook == {}
           " Prepend separator to start of description only if it was provided
-          if l:argDescription != ''
+          if l:argDescription !=# ''
             let l:argDescription = g:jsdoc_param_description_separator . l:argDescription
           endif
           call add(l:lines, l:space . ' * @' . g:jsdoc_tags['param'] . ' {' . l:argType . '} ' . l:arg . l:argDescription)
@@ -301,11 +314,11 @@ function! jsdoc#insert()
     if g:jsdoc_allow_input_prompt == 1
       let l:returnType = input('Return type (blank for no @' . g:jsdoc_tags['returns'] . '): ', '', 'custom,jsdoc#listDataTypes')
       let l:returnDescription = ''
-      if l:returnType != ''
+      if l:returnType !=# ''
         if g:jsdoc_return_description == 1
           let l:returnDescription = input('Return description: ')
         endif
-        if l:returnDescription != ''
+        if l:returnDescription !=# ''
           let l:returnDescription = ' ' . l:returnDescription
         endif
         call add(l:lines, l:space . ' * @' . g:jsdoc_tags['returns'] . ' {' . l:returnType . '}' . l:returnDescription)
@@ -324,11 +337,11 @@ function! jsdoc#insert()
   let l:pos = line('.') - (len(l:lines) - 1)
 
   silent! execute 'normal! ' . l:pos . 'G$'
-  if l:desc == '' && l:funcName != ''
+  if l:desc ==# '' && l:funcName !=# ''
     silent! execute 'normal! a' . l:funcName
   endif
 
-  let &g:paste = paste
+  let &g:paste = l:paste
 endfunction
 
 let &cpo = s:save_cpo

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,27 @@
+/*eslint-env es6*/
+// ES6 generator function
+
+var anonymousGeneratorFunctionExpression = function* (arg1, arg2) {};
+
+var namedGeneratorFunctionExpression = function* namedGenerator(arg1, arg2) {};
+
+var anonymousFunctionExpression = function (arg1, arg2) {};
+
+var namedFunctionExpression = function namedExpression(el, $jq) {}
+
+function namedFunctionDeclaration(_a2, err) { }
+
+function* namedGeneratorFunc(data) { }
+
+const namespace = {};
+
+namespace.x0 = function (e) { }; // anonymous method
+
+namespace.x1 = (e) => { }; // anonymous method shorthand
+
+namespace.x2 = function* (e) { }; // anonymous method generator
+
+namespace.x3 = function testing(e) { }; // named method
+
+namespace.x4 = function* testgen(description) { }; // named method generator
+


### PR DESCRIPTION
- Changed double quotes to single quotes where appropriate
- Use case matching (even for empty string comparisons)
- Scope function local and script variables
- Abort functions on error
- Rename regex descriptive keys in `s:regexs`
- Update regex in `s:regex` to support generator asterisks
- Add test file (manual testing for now)

fix #53 

note that it conflicts with #52 but easy merge (just take arrow regex from that one later)
