### PR TITLE
Fix readme markdown formatting (escape pipes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Option                                  | Default | Description
 **g:jsdoc_return**                      | 1       | Add the `@return` tag.
 **g:jsdoc_return_type**                 | 1       | Prompt for and add a type for the aforementioned `@return` tag.
 **g:jsdoc_return_description**          | 1       | Prompt for and add a description for the `@return` tag.
-**g:jsdoc_access_descriptions**         | 0       | Set value to 1 to turn on access tags like `@access <private|public>`. Set value to 2 to turn on access tags like `@<private|public>`
+**g:jsdoc_access_descriptions**         | 0       | Set value to 1 to turn on access tags like `@access <private\|public>`. Set value to 2 to turn on access tags like `@<private\|public>`
 **g:jsdoc_underscore_private**          | 0       | Set value to 1 to turn on detecting underscore starting functions as private convention
 **g:jsdoc_allow_shorthand**             | 0       | Set value to 1 to allow ECMAScript6 shorthand syntax. Since ver `0.5.0` deprecated. Use `g:jsdoc_enable_es6` instead.
 **g:jsdoc_param_description_separator** | ' '     | Characters used to separate `@param` name and description.
@@ -38,7 +38,7 @@ Option                                  | Default | Description
 **g:jsdoc_custom_args_regex_only**      | 0       | When using `custom_args_hook`, only match against regexes
 **g:jsdoc_type_hook**                   | {}      | Allow to insert default description depending on the type.
 **g:jsdoc_enable_es6**                  | 0       | Enable to use ECMAScript6's Shorthand function, Arrow function.
-**g:jsdoc_tags**                        | see :h  | Allow use of alternate tags (the ones that support synonyms) per JSDoc documentation. Can be changed on a per tag basis, for example: `let g:jsdoc_tags = {} | let g:jsdoc_tags['param'] = 'arg'`
+**g:jsdoc_tags**                        | see :h  | Allow use of alternate tags (the ones that support synonyms) per JSDoc documentation. Can be changed on a per tag basis, for example: `let g:jsdoc_tags = {} \| let g:jsdoc_tags['param'] = 'arg'`
 **g:jsdoc_user_defined_tags**           | {}     | Allow use of `user_defined_tags`.
 
 ## Keymap


### PR DESCRIPTION
I'm back, with just a tiny fix :smile: 

Noticed the rendering is broken

- Fixes markdown rendering of pipes in table by escaping them