### PR TITLE
add support for neovim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,12 @@ jobs:
     script:
       - cd $HOME/build/heavenshell/vim-jsdoc/tests
       - VIM_EXE=$HOME/bin/vim/bin/vim ./run.sh
+      
+  - env: ENV="Neovim"
+    install:
+      - mkdir -p ~/tmp/nvim/bin
+      - curl -L https://github.com/neovim/neovim/releases/download/v0.4.3/nvim.appimage -o ~/tmp/nvim/bin/nvim
+      - chmod u+x ~/tmp/nvim/bin/nvim
+
+    script:
+      - VIM_EXE=$HOME/tmp/nvim/bin/nvim ./run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ jobs:
       - chmod u+x ~/tmp/nvim/bin/nvim
 
     script:
+      - cd $HOME/build/heavenshell/vim-jsdoc/tests
       - VIM_EXE=$HOME/tmp/nvim/bin/nvim ./run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ jobs:
       - mkdir -p ~/tmp/nvim/bin
       - curl -L https://github.com/neovim/neovim/releases/download/v0.4.3/nvim.appimage -o ~/tmp/nvim/bin/nvim
       - chmod u+x ~/tmp/nvim/bin/nvim
+      
+    before_script:
+      - cd $HOME/build/heavenshell/vim-jsdoc
+      - make install
 
     script:
       - cd $HOME/build/heavenshell/vim-jsdoc/tests

--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -106,20 +106,35 @@ function! s:exit_callback(msg) abort
 endfunction
 
 function! s:vim.execute(cmd, lines, start_lineno, is_method, cb, ex_cb) dict
-  if exists('s:job') && job_status(s:job) != 'stop'
-    call job_stop(s:job)
-  endif
+  if has('nvim')
+    if exists('s:job') && jobwait([s:job], 0)[0] == -1
+      call jobstop(s:job)
+    endif
 
-  let s:job = job_start(a:cmd, {
-    \ 'callback': {_, m -> a:cb(m, a:start_lineno, a:is_method)},
-    \ 'exit_cb': {_, m -> a:ex_cb(m)},
-    \ 'in_mode': 'nl',
-    \ })
+    let s:job = jobstart(a:cmd, {
+          \ 'on_stdout': {_, m -> a:cb(m, a:start_lineno, a:is_method)},
+          \ 'on_exit': {_, m -> a:ex_cb(m)},
+          \ 'stdout_buffered': 1,
+          \ })
 
-  let channel = job_getchannel(s:job)
-  if ch_status(channel) ==# 'open'
-    call ch_sendraw(channel, a:lines)
-    call ch_close_in(channel)
+    call chansend(s:job, a:lines)
+    call chanclose(s:job, 'stdin')
+  elseif v:version >= 800 && !has('nvim')
+    if exists('s:job') && job_status(s:job) != 'dead'
+      call job_stop(s:job)
+    endif
+
+    let s:job = job_start(a:cmd, {
+          \ 'callback': {_, m -> a:cb(m, a:start_lineno, a:is_method)},
+          \ 'exit_cb': {_, m -> a:ex_cb(m)},
+          \ 'in_mode': 'nl',
+          \ })
+
+    let channel = job_getchannel(s:job)
+    if ch_status(channel) ==# 'open'
+      call ch_sendraw(channel, a:lines)
+      call ch_close_in(channel)
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
Notice that on vim 8.0+, `job_status` returns "run", "fail" or "dead". So I consider the `job_status` check branch is a bug.
Tested on `nvim v0.5.0-6ca7ebb`