### PR TITLE
Fix install.sh, also try npm

### DIFF
--- a/lib/install.sh
+++ b/lib/install.sh
@@ -4,5 +4,15 @@ set -e
 
 LIBDIR=$(cd $(dirname $0); pwd)
 
-yarn --cwd ${LIBDIR}
-ln -s "${LIBDIR}/node_modules/.bin/lehre" "${LIBDIR}/lehre"
+if [ -x "$(command -v yarn)" ]; then
+  yarn --cwd "${LIBDIR}"
+  ln -fs "${LIBDIR}/node_modules/.bin/lehre" "${LIBDIR}/lehre"
+elif [ -x "$(command -v npm)" ]; then
+  cd "$LIBDIR"
+  npm install
+  ln -fs "${LIBDIR}/node_modules/.bin/lehre" "${LIBDIR}/lehre"
+else
+  echo 'Neither yarn nor npm was found on your path' >&2
+  exit 1
+fi
+


### PR DESCRIPTION
Fix 1:
`yarn --cwd ${LIBDIR}`
Fails if there are spaces in the path. So that's quotes now.

Also added a check if npm is installed, and if so, try using it.

If neither are found, echoes a warning.