### PR TITLE
Do not dirty repo when installing via npm

### DIFF
--- a/lib/install.sh
+++ b/lib/install.sh
@@ -9,7 +9,7 @@ if [ -x "$(command -v yarn)" ]; then
   ln -fs "${LIBDIR}/node_modules/.bin/lehre" "${LIBDIR}/lehre"
 elif [ -x "$(command -v npm)" ]; then
   cd "$LIBDIR"
-  npm install
+  npm install --no-package-lock
   ln -fs "${LIBDIR}/node_modules/.bin/lehre" "${LIBDIR}/lehre"
 else
   echo 'Neither yarn nor npm was found on your path' >&2


### PR DESCRIPTION
Fixes https://github.com/heavenshell/vim-jsdoc/issues/103
Installing using `npm` results in `package-lock.json` being generated and `yarn.lock` being modified.
This change fixes this, although maybe replacing yarn with npm would be a better choice here