### PR TITLE
add windows support, and update the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,22 @@ make clean
 make install
 ```
 
-If you want install lehre manually, you can install from npm.
+If you want to install lehre manually, you can install from npm.
 
 ```console
 $ yarn add -D lehre
 ```
 
 Set installed `/path/to/node_modules/.bin/lehre` path to `g:jsdoc_lehre_path`.
+
+#### Installing on Windows
+
+```console
+# cd to <vim-jsdoc path>/lib
+npm install
+```
+
+If you want to set the path of [lehre](https://www.npmjs.com/package/lehre) manually on Windows, you should use the path with the file extension  `.cmd`, such as `/path/to/node_modules/.bin/lehre.cmd`.
 
 ## Usage
 

--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -10,17 +10,17 @@ set cpo&vim
 let g:jsdoc_templates_path = get(g:, 'jsdoc_templates_path', '')
 let g:jsdoc_formatter = get(g:, 'jsdoc_formatter', 'jsdoc')
 if has("win64") || has("win32") || has("win16")
-	let g:jsdoc_lehre_path = get(
-	  \ g:,
-	  \ 'jsdoc_lehre_path',
-	  \ printf('%s/lib/node_modules/.bin/lehre.cmd', expand('<sfile>:p:h:h'))
-	  \ )
+  let g:jsdoc_lehre_path = get(
+    \ g:,
+    \ 'jsdoc_lehre_path',
+    \ printf('%s/lib/node_modules/.bin/lehre.cmd', expand('<sfile>:p:h:h'))
+    \ )
 else
-	let g:jsdoc_lehre_path = get(
-	  \ g:,
-	  \ 'jsdoc_lehre_path',
-	  \ printf('%s/lib/lehre', expand('<sfile>:p:h:h'))
-	  \ )
+  let g:jsdoc_lehre_path = get(
+    \ g:,
+    \ 'jsdoc_lehre_path',
+    \ printf('%s/lib/lehre', expand('<sfile>:p:h:h'))
+    \ )
 endif
 
 let s:is_method_regex = '^.\{-}\s*\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*(\s*\([^)]*\)\s*).*$'

--- a/autoload/jsdoc.vim
+++ b/autoload/jsdoc.vim
@@ -9,11 +9,19 @@ set cpo&vim
 
 let g:jsdoc_templates_path = get(g:, 'jsdoc_templates_path', '')
 let g:jsdoc_formatter = get(g:, 'jsdoc_formatter', 'jsdoc')
-let g:jsdoc_lehre_path = get(
-  \ g:,
-  \ 'jsdoc_lehre_path',
-  \ printf('%s/lib/lehre', expand('<sfile>:p:h:h'))
-  \ )
+if has("win64") || has("win32") || has("win16")
+	let g:jsdoc_lehre_path = get(
+	  \ g:,
+	  \ 'jsdoc_lehre_path',
+	  \ printf('%s/lib/node_modules/.bin/lehre.cmd', expand('<sfile>:p:h:h'))
+	  \ )
+else
+	let g:jsdoc_lehre_path = get(
+	  \ g:,
+	  \ 'jsdoc_lehre_path',
+	  \ printf('%s/lib/lehre', expand('<sfile>:p:h:h'))
+	  \ )
+endif
 
 let s:is_method_regex = '^.\{-}\s*\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*(\s*\([^)]*\)\s*).*$'
 let s:is_declarelation = '^.\{-}=\s*\(\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*(\s*\([^)]*\)\s*)\|(\s*\([^)]*\)\s*\).*$'


### PR DESCRIPTION
Add windows installation guide to README.md. vim-jsdoc can work directly if user has installed lehre in `<vim-jsdoc path>/lib`